### PR TITLE
fix issue when client undefined

### DIFF
--- a/node-red-contrib-log/node-azure-appinsight.js
+++ b/node-red-contrib-log/node-azure-appinsight.js
@@ -37,20 +37,21 @@ const close = (done) => {
 
 // See https://github.com/Microsoft/ApplicationInsights-node.js/tree/master
 const input = (node, data, config) => {
+    if (client) {
+        let log =  config.log || "payload";
+        if (config.logType === "msg") log = helper.getByString(data, log) ;
+        let name = (config.evtnameType === "msg") ?  helper.getByString(data, config.evtname) : config.evtname;
+        let type = config.evttype || 'event';
 
-    let log =  config.log || "payload";
-    if (config.logType === "msg") log = helper.getByString(data, log) ;
-    let name = (config.evtnameType === "msg") ?  helper.getByString(data, config.evtname) : config.evtname;
-    let type = config.evttype || 'event';
-
-    if (type === 'event'){
-        client.trackEvent(name, log);
-    } else if (type === 'metric'){
-        client.trackMetric(name, parseInt(log));
-    } else if (type === 'trace'){
-        client.trackTrace(log);
-    } else if (type === 'error'){
-        client.trackException(new Error(log));
+        if (type === 'event'){
+            client.trackEvent(name, log);
+        } else if (type === 'metric'){
+            client.trackMetric(name, parseInt(log));
+        } else if (type === 'trace'){
+            client.trackTrace(log);
+        } else if (type === 'error'){
+            client.trackException(new Error(log));
+        }
     }
 
     node.send(data);


### PR DESCRIPTION
Fix error when appInsights client is undefined (ex: appInsights instrumentation key not provided).

It allows to disable appInsights logs in dev environment by setting the instrumentation key to an empty value.